### PR TITLE
Convert query of #findOne() to have idProperty of type ObjectID

### DIFF
--- a/lib/mongodb-engine.js
+++ b/lib/mongodb-engine.js
@@ -157,6 +157,10 @@ module.exports = function (collection, engineOptions) {
       callback = options
       options = {}
     }
+    var id = query[engineOptions.idProperty]
+    if (id) {
+      query[engineOptions.idProperty] = id = new ObjectID(id)
+    }
     self.emit('findOne', query)
     collection.findOne(query, options, function (error, entity) {
       if (error) {


### PR DESCRIPTION
This allows you to find by ID in your application without first having to convert your query to ObjectID on the application side:

Before:

```
userService.findOne({ _id: new ObjectID(user._id) }, function (err, entity) {})
```

After:

```
userService.findOne({ _id: user._id }, function (err, entity) {})
```
