### PR TITLE
Fix erroneous DB connect options for tests

### DIFF
--- a/test/mongodb-engine.test.js
+++ b/test/mongodb-engine.test.js
@@ -2,8 +2,8 @@ var Db = require('mongodb').Db
   , Server = require('mongodb').Server
   , collection
 
-var db = new Db('test', new Server('127.0.0.1', 27017,
-  { safe: true, journal: true, fsync: true,  w: 'majority' }))
+var db = new Db('test', new Server('127.0.0.1', 27017, {}),
+  {fsync: true, w: 1})
 
 function getEngine(callback) {
   collection.remove({}, function () {


### PR DESCRIPTION
I've set default connect options to {fsync: true, w: 1} because fsync is required for tests to pass correctly, and w: "majority" causes a timeout if there is no replica set.
