### PR TITLE
Resolving an issue which prevented the overriding of the idProperty in engineOptions.

### DIFF
--- a/lib/mongodb-engine.js
+++ b/lib/mongodb-engine.js
@@ -5,8 +5,7 @@ var _ = require('lodash')
 
 module.exports = function (collection, engineOptions) {
   var self = new EventEmitter()
-    , options = _.extend({}, engineOptions,
-        { idProperty: '_id' })
+    , options = _.extend({ idProperty: '_id' }, engineOptions)
 
   function create(object, callback) {
     callback = callback || emptyFn

--- a/lib/mongodb-engine.js
+++ b/lib/mongodb-engine.js
@@ -5,9 +5,18 @@ var _ = require('lodash')
 
 module.exports = function (collection, engineOptions) {
   var self = new EventEmitter()
+    , idParser = function (value) {
+        try {
+          return new ObjectID(value)
+        } catch (e) {
+          if (e.message === 'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters') {
+            return value
+          }
+        }
+      }
     , defaultOptions =
         { idProperty: '_id'
-        , castIdToObject: true
+        , idParser: idParser
         }
     , options = _.extend(defaultOptions, engineOptions)
 
@@ -58,22 +67,9 @@ module.exports = function (collection, engineOptions) {
       return newQuery
     }
 
-    // only convert if key is an object ID
-    if (!options.castIdToObject) {
-      console.log('not converting')
-      return newQuery
-    }
-
-    try {
-      newQuery[options.idProperty] = new ObjectID(newQuery[options.idProperty])
-    } catch (e) {
-      if (e.message === 'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters') {
-        return newQuery
-      }
-    }
+    newQuery[options.idProperty] = options.idParser(newQuery[options.idProperty])
 
     return newQuery
-
   }
 
   function read(id, callback) {

--- a/lib/mongodb-engine.js
+++ b/lib/mongodb-engine.js
@@ -5,7 +5,11 @@ var _ = require('lodash')
 
 module.exports = function (collection, engineOptions) {
   var self = new EventEmitter()
-    , options = _.extend({ idProperty: '_id' }, engineOptions)
+    , defaultOptions =
+        { idProperty: '_id'
+        , castIdToObject: true
+        }
+    , options = _.extend(defaultOptions, engineOptions)
 
   function create(object, callback) {
     callback = callback || emptyFn
@@ -51,6 +55,12 @@ module.exports = function (collection, engineOptions) {
     var newQuery = _.extend({}, query)
     // only convert if id is present
     if (!query[options.idProperty]) {
+      return newQuery
+    }
+
+    // only convert if key is an object ID
+    if (!options.castIdToObject) {
+      console.log('not converting')
       return newQuery
     }
 


### PR DESCRIPTION
The order of precedence on _.extend was the wrong way around preventing anyone overwriting idProperty. Also the blank object at the start is not necessary after the reversal.
