### PR TITLE
update: Throw error if there is one

### DIFF
--- a/lib/mongodb-engine.js
+++ b/lib/mongodb-engine.js
@@ -102,6 +102,10 @@ module.exports = function (collection, engineOptions) {
     delete updateObject[options.idProperty]
     collection.findAndModify(castIdProperty(query), [['_id', 'asc']], updateData,
       { 'new': true }, function (error, entity) {
+        
+      if (error) {
+        return callback(error)
+      }
 
       if (!entity) {
         callback(new Error('No object found with \'' + options.idProperty +
@@ -109,7 +113,7 @@ module.exports = function (collection, engineOptions) {
       } else {
         entity = objectIdToString(entity)
         self.emit('afterUpdate', entity)
-        callback(error, entity)
+        callback(null, entity)
       }
     })
   }


### PR DESCRIPTION
Beforehand, if there was no entity but there was an error, that error would not be propagated (via the callback).
