### PR TITLE
Modify call to `collection.find()` to remove empty fields object

### DIFF
--- a/lib/mongodb-engine.js
+++ b/lib/mongodb-engine.js
@@ -203,7 +203,7 @@ module.exports = function (collection, engineOptions) {
       throw new Error('callback must be a function')
     }
     self.emit('find', query)
-    collection.find(castIdProperty(query), {}, options).toArray(function (error, data) {
+    collection.find(castIdProperty(query), options).toArray(function (error, data) {
 
       if (error) {
         return callback(error)


### PR DESCRIPTION
According to the docs:
http://mongodb.github.io/node-mongodb-native/api-generated/collection.html#find

The only time when you would call it with 3 arguments (ignoring the callback) is
`find(selector, fields, options)`, this is not what we are doing so it should
be removed. We only ever specify fields in `options`.

Also the only place where the projection query can be is in the 2nd argument.
http://docs.mongodb.org/manual/reference/operator/projection/meta/#projection
This is necessary to return the `textScore` $meta associated with a full text
search result. For some reason it does not work as an option in the 3rd argument.

The tests are currently failing due to some issues with some ObjectID equality statements:
`Uncaught AssertionError: expected '53e8ce9929b88259bdd0edd8' to be 53e8ce9929b88259bdd0edd8`. They are also failing on master however, so I don't believe it is a problem with this code. I think it is related to https://github.com/serby/save/pull/24 but im not 100% sure. 
