### PR TITLE
Use through2 for Transform stream

### DIFF
--- a/lib/mongodb-engine.js
+++ b/lib/mongodb-engine.js
@@ -4,7 +4,7 @@ var _ = require('lodash')
   , emptyFn = function () {}
   , EventEmitter = require('events').EventEmitter
   , ObjectID = require('mongodb').ObjectID
-  , through = require('through')
+  , through = require('through2')
 
 function createEngine(collection, engineOptions) {
   var self = new EventEmitter()
@@ -200,11 +200,11 @@ function createEngine(collection, engineOptions) {
     if (callback === undefined) {
       self.emit('find', query, options)
 
-      var throughStream = through(function (data) {
-        this.queue(objectIdToString(data))
+      var convertIdStream = through.obj(function (chunk, enc, cb) {
+        cb(null, objectIdToString(chunk))
       })
 
-      return collection.find(castIdProperty(query), options).stream().pipe(throughStream)
+      return collection.find(castIdProperty(query), options).stream().pipe(convertIdStream)
 
     } else if (typeof callback !== 'function') {
       throw new Error('callback must be a function')

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "lodash": "^2.4.1",
     "mongodb": "^1.4.28",
-    "through": "^2.3.6"
+    "through2": "^2.0.0"
   },
   "devDependencies": {
     "async": "^0.9.0",


### PR DESCRIPTION
Using through meant that if the data was read from the find()
readStream asynchronously, any data events prior to the read()
or pipe() would be lost. This is due to the incompatibility of
stream backpressure.

Using through2 the data is correctly buffered, so that the data
is ready to read whenever the consumer is ready.

This PR includes a test that fails when through is used and passes when through2 is introduced.

NB.
I also added a load of load of missing `if (err) return done(err)`s in tests and gave the transform stream a better name.