### PR TITLE
Resolves issue where an idProperty query doesnt cast strings to ObjectIDs

### DIFF
--- a/lib/cast-id-property.js
+++ b/lib/cast-id-property.js
@@ -1,0 +1,42 @@
+module.exports = init
+
+var ObjectID = require('mongodb').ObjectID
+
+function init (property) {
+  return castIdProperty
+
+  function castIdProperty (query) {
+    var newQuery = Object.assign({}, query)
+    var idQuery = query[property]
+    // only convert if id is present
+    if (!idQuery) {
+      return newQuery
+    }
+
+    if (Object(idQuery) === idQuery) {
+      newQuery[property] = castComplexId(idQuery)
+    } else {
+      newQuery[property] = ObjectID.isValid(newQuery[property])
+        ? new ObjectID(newQuery[property]) : newQuery[property]
+    }
+
+    return newQuery
+  }
+
+  function castComplexId (query) {
+    var newQuery = Object.assign({}, query)
+
+    Object.keys(newQuery).map(function (key) {
+      var value = newQuery[key]
+      if (Array.isArray(value)) {
+        newQuery[key] = value.map(function (item) {
+          return ObjectID.isValid(item) ? new ObjectID(item) : item
+        })
+      } else {
+        newQuery[key] = ObjectID.isValid(value) ? new ObjectID(value) : value
+      }
+    })
+
+    return newQuery
+  }
+}

--- a/lib/mongodb-engine.js
+++ b/lib/mongodb-engine.js
@@ -4,10 +4,12 @@ var emptyFn = function () {}
 var ObjectID = require('mongodb').ObjectID
 var through = require('through2')
 var es = require('event-stream')
+var createCastIdProperty = require('./cast-id-property')
 
 function createEngine (collection, engineOptions) {
   var self = es.map(createOrUpdate)
   var options = Object.assign({}, { idProperty: '_id' }, engineOptions)
+  var castIdProperty = createCastIdProperty(options.idProperty)
 
   function create (object, callback) {
     callback = callback || emptyFn
@@ -42,47 +44,6 @@ function createEngine (collection, engineOptions) {
         }
       })
     }
-  }
-
-  function castIdProperty (query) {
-    var newQuery = Object.assign({}, query)
-    var idQuery = query[options.idProperty]
-    // only convert if id is present
-    if (!idQuery) {
-      return newQuery
-    }
-
-    try {
-      if (Object(idQuery) === idQuery) {
-        newQuery[options.idProperty] = castComplexId(idQuery)
-      } else {
-        newQuery[options.idProperty] = ObjectID.isValid(newQuery[options.idProperty])
-          ? new ObjectID(newQuery[options.idProperty]) : newQuery[options.idProperty]
-      }
-    } catch (e) {
-      if (e.message === 'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters') {
-        return newQuery
-      }
-    }
-
-    return newQuery
-  }
-
-  function castComplexId (query) {
-    var newQuery = Object.assign({}, query)
-
-    Object.keys(newQuery).map(function (key) {
-      var value = newQuery[key]
-      if (Array.isArray(value)) {
-        newQuery[key] = value.map(function (item) {
-          return ObjectID.isValid(item) ? new ObjectID(item) : item
-        })
-      } else {
-        newQuery[key] = ObjectID.isValid(value) ? new ObjectID(value) : value
-      }
-    })
-
-    return newQuery
   }
 
   function read (id, callback) {
@@ -207,14 +168,12 @@ function createEngine (collection, engineOptions) {
         self.emit('received', mappedData)
         cb(null, mappedData)
       })
-
       return collection.find(castIdProperty(query), options).pipe(convertIdStream)
     } else if (typeof callback !== 'function') {
       throw new Error('callback must be a function')
     }
     // Callback implementation - Uses lots of memory
     self.emit('find', query, options)
-
     collection.find(castIdProperty(query), options).toArray(function (error, data) {
       if (error) return callback(error)
       var mappedData = data.map(objectIdToString)

--- a/lib/mongodb-engine.js
+++ b/lib/mongodb-engine.js
@@ -56,7 +56,8 @@ function createEngine (collection, engineOptions) {
       if (Object(idQuery) === idQuery) {
         newQuery[options.idProperty] = castComplexId(idQuery)
       } else {
-        newQuery[options.idProperty] = new ObjectID(newQuery[options.idProperty])
+        newQuery[options.idProperty] = ObjectID.isValid(newQuery[options.idProperty])
+          ? new ObjectID(newQuery[options.idProperty]) : newQuery[options.idProperty]
       }
     } catch (e) {
       if (e.message === 'Argument passed in must be a single String of 12 bytes or a string of 24 hex characters') {
@@ -74,10 +75,10 @@ function createEngine (collection, engineOptions) {
       var value = newQuery[key]
       if (Array.isArray(value)) {
         newQuery[key] = value.map(function (item) {
-          return new ObjectID(item)
+          return ObjectID.isValid(item) ? new ObjectID(item) : item
         })
       } else {
-        newQuery[key] = new ObjectID(value)
+        newQuery[key] = ObjectID.isValid(value) ? new ObjectID(value) : value
       }
     })
 

--- a/test/cast-id-property.test.js
+++ b/test/cast-id-property.test.js
@@ -1,0 +1,42 @@
+var assert = require('assert')
+var ObjectID = require('mongodb').ObjectID
+var castIdProperty = require('../lib/cast-id-property')
+
+describe('cast-id-property', function () {
+  it('should return original query if idProperty doesnt exist in query', function () {
+    var query = { a: 'something' }
+    var result = castIdProperty('_id')(query)
+    assert.deepEqual(result, query)
+  })
+
+  it('should return cast property if single value provided', function () {
+    var objectId = new ObjectID()
+    var query = { _id: objectId.toString() }
+    var result = castIdProperty('_id')(query)
+    assert.deepEqual(result, { _id: objectId })
+  })
+
+  it('should return string if single string value provided', function () {
+    var stringA = 'something'
+    var query = { _id: { $neq: stringA } }
+    var result = castIdProperty('_id')(query)
+    assert.deepEqual(result, query)
+  })
+
+  it('should return cast object if object provided', function () {
+    var objectA = new ObjectID()
+    var objectB = new ObjectID()
+    var query = { _id: { $in: [ objectA.toString(), objectB.toString() ] } }
+    var result = castIdProperty('_id')(query)
+    assert.deepEqual(result, { _id: { $in: [ objectA, objectB ] } })
+  })
+
+  it('should cast only object if mixture is provided', function () {
+    var objectA = new ObjectID()
+    var objectB = new ObjectID()
+    var stringA = 'something'
+    var query = { _id: { $in: [ objectA.toString(), stringA, objectB.toString() ] } }
+    var result = castIdProperty('_id')(query)
+    assert.deepEqual(result, { _id: { $in: [ objectA, stringA, objectB ] } })
+  })
+})

--- a/test/mongodb-engine.test.js
+++ b/test/mongodb-engine.test.js
@@ -155,4 +155,43 @@ describe('mongodb-engine', function () {
       })
     })
   })
+
+  describe('castIdProperty()', function () {
+    it('should correctly cast valid ObjectIDs when only valid ids passed', function (done) {
+      getEngine(function (err, engine) {
+        if (err) return done(err)
+        const objects = [ { a: 1 }, { a: 2 }, { a: 3 } ]
+        mapSeries(objects, engine.create, function (err, documents) {
+          if (err) return done(err)
+          var query = {}
+          query[idProperty] = { $in:
+            [ documents[0][idProperty], documents[1][idProperty], documents[2][idProperty] ]
+          }
+          engine.find(query, function (err, queryResults) {
+            if (err) return done(err)
+            assert.equal(queryResults.length, 3)
+            done()
+          })
+        })
+      })
+    })
+    it('should correctly cast only valid ObjectIDs and return others untouched when mix of ids', function (done) {
+      getEngine(function (err, engine) {
+        if (err) return done(err)
+        const objects = [ { a: 1 }, { _id: '34', a: 2 }, { _id: '767', a: 3 }, { a: 4 } ]
+        mapSeries(objects, engine.create, function (err, documents) {
+          if (err) return done(err)
+          var query = {}
+          query[idProperty] = { $in:
+            [ documents[0][idProperty], '34', '767', documents[3][idProperty] ]
+          }
+          engine.find(query, function (err, queryResults) {
+            if (err) return done(err)
+            assert.equal(queryResults.length, 4)
+            done()
+          })
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
Scenario 1: `const query = { _id: { $in: [ '5b44cb02bf2d0405ecbce3cf' ] } }`
Scenario 2: `const query = { _id: { $in: [ '5b44cb02bf2d0405ecbce3cf', '123' ] } }`
Scenario 3: `const query = { _id: { $in: [ '5b44cb02bf2d0405ecbce3cf', '5b44d4a59dba5a1550d67993', '5b44d697740a6405f7f2b105' ] } }`

When the Scenario 1 was run '5b44cb02bf2d0405ecbce3cf' was correctly cast to an ObjectID.
However Scenario 2 wouldnt cast '5b44cb02bf2d0405ecbce3cf' to an ObjectID and thus the query would only find one document.
Scenario 3 would return every item correct cast to an ObjectID.

The reason for this was due to `new ObjectID('non ObjectID string')` throwing an error if the value passed was an invalid ObjectID. The error was then caught here: https://github.com/serby/save-mongodb/blob/master/lib/mongodb-engine.js#L62-L64 and the original query is returned.

This has only come to light on Leicester Tigers due to the mixture of ObjectID values.

Ive changed every instance of `new ObjectId(value)` to be a ternary check to leverage ObjectID.isValid. This results in the Scenario 2 being correct cast for ObjectID strings only. All other tests continue to pass.

I haven't written any tests for this, as I need to test the `castIdProperty` function, which is currently not exposed. If you are happy for me to expose the function then ill add the tests. If not the other option is to use rewire? Let me know your thoughts

Sorry for two PRs in so many days